### PR TITLE
Change root user to developer

### DIFF
--- a/my-inventory
+++ b/my-inventory
@@ -6,8 +6,8 @@ ansible_python_interpreter="/usr/bin/env python"
 sandbox1 ansible_host='ios-xe-mgmt.cisco.com'
 
 [sandbox:vars]
-username=root
-password=D_Vay!_10&
+username=developer
+password=C1sco12345
 port=8181
 
 [homelab]


### PR DESCRIPTION
The `root` user and credentials no longer work for the Always-on IOS XE Sandbox at `ios-xe-mgmt.cisco.com` so the inventory file should change. @WendellOdom Can you merge as soon as you get a chance? Thanks.